### PR TITLE
fix: Prefer 'pleo-io' to 'pleo-oss'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
-    "name": "@pleo-oss/s3-cache-action",
+    "name": "@pleo-io/s3-cache-action",
     "version": "2.0.1",
     "dependencies": {
         "@actions/core": "1.9.0",


### PR DESCRIPTION
This will move the configuration from the soon-to-be-closed `pleo-oss` to `pleo-io`.