### PR TITLE
fix: Prefer 'pleo-io' to 'pleo-oss'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,4 +16,4 @@ jobs:
               id: release
               with:
                   release-type: node
-                  package-name: '@pleo-oss/s3-cache-action'
+                  package-name: '@pleo-io/s3-cache-action'

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ order to determine the repo state.
 - uses: aws-actions/configure-aws-credentials@v1
   with:
       # See aws-actions/configure-aws-credentials docs
-- uses: pleo-oss/s3-cache-action@v1
+- uses: pleo-io/s3-cache-action@v1
   id: s3-cache
   with:
       bucket-name: my-s3-bucket

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
-    "name": "@pleo-oss/s3-cache-action",
+    "name": "@pleo-io/s3-cache-action",
     "version": "2.0.1",
     "dependencies": {
         "@actions/core": "1.9.0",


### PR DESCRIPTION
This will move the configuration from the soon-to-be-closed `pleo-oss` to `pleo-io`.