### PR TITLE
fix: Prefer 'pleo-io' to 'pleo-oss'

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ order to determine the repo state.
 - uses: aws-actions/configure-aws-credentials@v1
   with:
       # See aws-actions/configure-aws-credentials docs
-- uses: pleo-oss/s3-cache-action@v1
+- uses: pleo-io/s3-cache-action@v1
   id: s3-cache
   with:
       bucket-name: my-s3-bucket


### PR DESCRIPTION
This will move the configuration from the soon-to-be-closed `pleo-oss` to `pleo-io`.