### PR TITLE
chore!: update node to 20 in s3-cache-action

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ order to determine the repo state.
 
 ## Runs
 
-This action is a `node16` action.
+This action is a `node20` action.
 
 <!-- action-docs-runs -->
 

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ outputs:
     hash:
         description: The repo tree hash which was used for caching.
 runs:
-    using: node16
+    using: node20
     main: dist/restore/index.js
     post: dist/save/index.js
     post-if: success()


### PR DESCRIPTION
We're currently using node 16 in s3-cache-action, which is deprecated in github.
This PR updates to node 20.